### PR TITLE
ユーザーを作成するAPIを追加した

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@
 erDiagram
     USERS {
         INTEGER id PK "Primary Key"
-        VARCHAR name "ユーザー名"
         VARCHAR email "メールアドレス"
         VARCHAR password_hash "パスワードハッシュ"
         TIMESTAMP created_at "作成日時"

--- a/backend/README.md
+++ b/backend/README.md
@@ -20,7 +20,6 @@ Supabase の SQL Editor で以下の SQL 文を実行する．
 ```sql
 CREATE TABLE users (
     id SERIAL PRIMARY KEY,
-    name VARCHAR(50) NOT NULL UNIQUE,
     email VARCHAR(255) NOT NULL UNIQUE,
     password_hash VARCHAR(255) NOT NULL,
     created_at TIMESTAMP(0) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,13 +1,14 @@
 import os
 from datetime import timedelta
 
+from dotenv import load_dotenv
 from flask import Flask, request
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager
 from routes.auth import auth_bp
 from routes.my_dream import my_dream_bp
 from routes.public_dream import public_dream_bp
-from dotenv import load_dotenv
+from routes.user import user_bp
 
 load_dotenv()
 app = Flask(__name__)
@@ -38,6 +39,7 @@ jwt = JWTManager(app)  # init_app(app) は不要
 app.register_blueprint(auth_bp)
 app.register_blueprint(my_dream_bp)
 app.register_blueprint(public_dream_bp)
+app.register_blueprint(user_bp)
 
 
 @app.route("/test", methods=["GET"])

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -9,14 +9,12 @@ class User:
     def __init__(
         self,
         id: int,
-        name: str,
         email: str,
         password_hash: str,
         created_at: str,
         updated_at: str,
     ):
         self.id = id
-        self.name = name
         self.email = email
         self.password_hash = password_hash
         self.created_at = created_at
@@ -49,13 +47,13 @@ class User:
         return check_password_hash(self.password_hash, password)
 
     @classmethod
-    def create_user(cls, username, email, password):
+    def create_user(cls, email, password):
         password_hash = generate_password_hash(password)
 
         supabase: Client = get_supabase_client()
         response = (
             supabase.table("users")
-            .insert({"username": username, "email": email, "password_hash": password_hash})
+            .insert({"email": email, "password_hash": password_hash})
             .execute()
         )  # fmt: skip
         return cls(**response.data[0])

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -47,7 +47,7 @@ class User:
         return check_password_hash(self.password_hash, password)
 
     @classmethod
-    def create_user(cls, email, password):
+    def create_user(cls, email: str, password: str) -> User:
         password_hash = generate_password_hash(password)
 
         supabase: Client = get_supabase_client()

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -19,7 +19,6 @@ def login():
         # ユーザー情報を返す
         response_data = {
             "id": "{}".format(user.id),
-            "name": "{}".format(user.name),
             "email": "{}".format(user.email),
         }
         response = jsonify(response_data)

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -8,24 +8,23 @@ auth_bp = Blueprint("auth", __name__)
 # ログイン機能
 @auth_bp.route("/login", methods=["POST"])
 def login():
-    if request.method == "POST":
-        # データ取得
-        credentials = request.get_json()
-        email = credentials["email"]
-        password = credentials["password"]
-        # ユーザー情報を取得
-        user = User.get_user_by_email(email)
-        if user and user.check_password(password):
-            access_token = create_access_token(identity=str(user.id))
-            # ユーザー情報を返す
-            response_data = {
-                "id": "{}".format(user.id),
-                "name": "{}".format(user.name),
-                "email": "{}".format(user.email),
-            }
-            response = jsonify(response_data)
-            # header に JWT を仕込む
-            response.headers["Authorization"] = "Bearer {}".format(access_token)
-            return response
-        else:
-            return "", 401  # failed
+    # データ取得
+    credentials = request.get_json()
+    email = credentials["email"]
+    password = credentials["password"]
+    # ユーザー情報を取得
+    user = User.get_user_by_email(email)
+    if user and user.check_password(password):
+        access_token = create_access_token(identity=str(user.id))
+        # ユーザー情報を返す
+        response_data = {
+            "id": "{}".format(user.id),
+            "name": "{}".format(user.name),
+            "email": "{}".format(user.email),
+        }
+        response = jsonify(response_data)
+        # header に JWT を仕込む
+        response.headers["Authorization"] = "Bearer {}".format(access_token)
+        return response
+    else:
+        return "", 401  # failed

--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -1,0 +1,20 @@
+from flask import Blueprint, jsonify, request
+from models.user import User
+
+user_bp = Blueprint("user", __name__)
+
+
+@user_bp.route("/users", methods=["POST"])
+def create_user():
+    data = request.get_json()
+    email = data.get("email")
+    password = data.get("password")
+
+    if email is None:
+        return "Email is required", 400
+
+    if password is None:
+        return "Password is required", 400
+
+    new_user = User.create_user(email, password)
+    return jsonify(new_user.__dict__), 201

--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -17,4 +17,4 @@ def create_user():
         return "Password is required", 400
 
     new_user = User.create_user(email, password)
-    return jsonify(new_user.__dict__), 201
+    return jsonify({"id": new_user.id, "email": new_user.email}), 201

--- a/backend/seeds/users.sql
+++ b/backend/seeds/users.sql
@@ -1,6 +1,6 @@
 INSERT INTO
-  users (name, email, password_hash)
+  users (email, password_hash)
 VALUES
-  ('testuser1', 'testuser1@example.com', 'pbkdf2:sha256:260000$kPdtHopNiQrAsNfB$f21ec91948dbc5ed7bde72a07af0aaa9f44e17ba037892b5c9c3f4d480b65703'),
-  ('testuser2', 'testuser2@example.com', 'pbkdf2:sha256:260000$kPdtHopNiQrAsNfB$f21ec91948dbc5ed7bde72a07af0aaa9f44e17ba037892b5c9c3f4d480b65703'),
-  ('testuser3', 'testuser3@example.com', 'pbkdf2:sha256:260000$kPdtHopNiQrAsNfB$f21ec91948dbc5ed7bde72a07af0aaa9f44e17ba037892b5c9c3f4d480b65703');
+  ('testuser1@example.com', 'pbkdf2:sha256:260000$kPdtHopNiQrAsNfB$f21ec91948dbc5ed7bde72a07af0aaa9f44e17ba037892b5c9c3f4d480b65703'),
+  ('testuser2@example.com', 'pbkdf2:sha256:260000$kPdtHopNiQrAsNfB$f21ec91948dbc5ed7bde72a07af0aaa9f44e17ba037892b5c9c3f4d480b65703'),
+  ('testuser3@example.com', 'pbkdf2:sha256:260000$kPdtHopNiQrAsNfB$f21ec91948dbc5ed7bde72a07af0aaa9f44e17ba037892b5c9c3f4d480b65703');

--- a/openapi.yml
+++ b/openapi.yml
@@ -39,7 +39,14 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/User"
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: integer
+                  email:
+                    type: string
+                    format: email
         '401':
           description: Unauthorized
 
@@ -212,12 +219,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: integer
+                  email:
+                    type: string
+                    format: email
         '400':
           description: BadRequest
-        '404':
-          description: Not Found
-
 
 components:
   schemas:

--- a/openapi.yml
+++ b/openapi.yml
@@ -7,6 +7,8 @@ servers:
 tags: 
   - name: dreams
     description: 夢に関するAPI
+  - name: users
+    description: ユーザーに関するAPI
   - name: auth
     description: 認証に関するAPI
 paths:
@@ -183,6 +185,39 @@ paths:
                 $ref: '#/components/schemas/Dream'
         '404':
           description: Not Found
+  /users:
+    post: 
+      tags: 
+        -  users
+      summary: ユーザーを作成する
+      operationId: createUser
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+              required:
+                - email
+                - password
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '400':
+          description: BadRequest
+        '404':
+          description: Not Found
+
 
 components:
   schemas:
@@ -215,11 +250,17 @@ components:
         id:
           type: string
           format: integer
-        name:
-          type: string
         email:
           type: string
           format: email
+        password_hash:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
 
   securitySchemes:
     BearerAuth:

--- a/openapi.yml
+++ b/openapi.yml
@@ -192,6 +192,7 @@ paths:
                 $ref: '#/components/schemas/Dream'
         '404':
           description: Not Found
+
   /users:
     post: 
       tags: 


### PR DESCRIPTION
## Issue

- Close #15 

## 概要

タイトル参照

## やったこと

- APIの仕様書にユーザー作成のAPIを追記した
- ユーザーのスキーマからユーザー名を削除した
- ユーザー作成のAPIを実装した

##  動作確認方法

動作確認するにはSupabaseの `users` テーブルから `name` を削除する必要がある．
今削除するとデプロイ中のサービスが動作しなくなる．
フロントエンドの #23 をマージした後に動作確認用のブランチを切る

