### PR TITLE
20 sort my dream backend

### DIFF
--- a/backend/models/dream.py
+++ b/backend/models/dream.py
@@ -24,7 +24,7 @@ class Dream:
         self.updated_at = updated_at
 
     @classmethod
-    def get_all_by_user(cls, user_id: str) -> list[Dream]:
+    def get_all_by_user(cls, user_id: str, sort: str) -> list[Dream]:
         # ユーザーの夢を全て取得
         supabase: Client = get_supabase_client()
 
@@ -32,8 +32,8 @@ class Dream:
             supabase.table("dreams")
             .select("*")
             .eq("user_id", user_id)
-            # id順で取得
-            .order("id", desc=True)
+            # ソート条件を受け取って適用
+            .order(sort, desc=True)
             .execute()
         )
         my_dreams = [cls(**dream) for dream in response.data]

--- a/backend/routes/my_dream.py
+++ b/backend/routes/my_dream.py
@@ -10,7 +10,16 @@ my_dream_bp = Blueprint("my_dream", __name__)
 @jwt_required()
 def get_my_dreams():
     user_id = get_jwt_identity()
-    dreams = Dream.get_all_by_user(user_id)
+    # クエリパラメータの受け取り
+    # デフォルトは作成日時順
+    sort_by = request.args.get("sort_by","updated_at")
+    # ソート条件に使えるカラム指定
+    valid_sort_val = {"likes","updated_at"}
+
+    if sort_by not in valid_sort_val:
+        return jsonify({"error": "Invalid sort_by field"}), 400
+
+    dreams = Dream.get_all_by_user(user_id,sort_by)
     return jsonify([dream.__dict__ for dream in dreams]), 200
 
 

--- a/frontend/src/api/dreams/mine.ts
+++ b/frontend/src/api/dreams/mine.ts
@@ -2,13 +2,13 @@ import { RequestDream } from "@/types/dream";
 
 const ENDPOINT = import.meta.env.VITE_API_ENDPOINT as string;
 
-export const fetchMyDreams = async () => {
+export const fetchMyDreams = async ( sortBy = "updated_at" ) => {
   const token = sessionStorage.getItem("token");
   if (!token) {
     throw new Error("ログインしていません");
   }
 
-  const response = await fetch(`${ENDPOINT}/dreams/mine`, {
+  const response = await fetch(`${ENDPOINT}/dreams/mine?sort_by=${sortBy}`, {
     method: "GET",
     headers: {
       Authorization: `${token}`,

--- a/frontend/src/pages/dreams/mine/MyDreamPage.tsx
+++ b/frontend/src/pages/dreams/mine/MyDreamPage.tsx
@@ -8,9 +8,11 @@ import SakuraScatterEffect from "../components/SakuraScatterEffect";
 import MyDreamCards from "./MyDreamCards";
 import MyDreamInput from "./MyDreamInput";
 
+export type MyDreamSortKey = "updated_at" | "likes";
+
 const MyDreamPage = () => {
   const [myDreams, setMyDreams] = useState<Dream[]>([]);
-  const [sortBy, setSortBy] = useState<"updated_at" | "likes">("updated_at");
+  const [sortKey, setSortKey] = useState<MyDreamSortKey>("updated_at");
   const { setIsLoading } = useContext(LoadingContext);
   const navigate = useNavigate();
 
@@ -24,7 +26,7 @@ const MyDreamPage = () => {
     const loadMyDreams = async () => {
       try {
         setIsLoading(true);
-        const dreams: Dream[] = await fetchMyDreams(sortBy);
+        const dreams: Dream[] = await fetchMyDreams(sortKey);
         setMyDreams(dreams);
       } catch (e) {
         console.error(e);
@@ -34,7 +36,7 @@ const MyDreamPage = () => {
     };
 
     loadMyDreams();
-  }, [sortBy]);
+  }, [sortKey]);
 
   return (
     <div>
@@ -47,9 +49,9 @@ const MyDreamPage = () => {
         <div className="mt-3 ml-5 flex items-center gap-2">
           <span className="text-gray-600">並び替え:</span>
           <select
-            value={sortBy}
-            onChange={(e) => {
-              setSortBy(e.target.value as "updated_at" | "likes");
+            value={sortKey}
+            onChange={(event) => {
+              setSortKey(event.target.value as MyDreamSortKey);
             }}
             className="border rounded px-3 py-1 bg-white text-gray-800 shadow-sm"
           >

--- a/frontend/src/pages/dreams/mine/MyDreamPage.tsx
+++ b/frontend/src/pages/dreams/mine/MyDreamPage.tsx
@@ -10,8 +10,8 @@ import MyDreamInput from "./MyDreamInput";
 
 const MyDreamPage = () => {
   const [myDreams, setMyDreams] = useState<Dream[]>([]);
+  const [sortBy, setSortBy] = useState<"updated_at" | "likes">("updated_at");
   const { setIsLoading } = useContext(LoadingContext);
-
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -24,8 +24,7 @@ const MyDreamPage = () => {
     const loadMyDreams = async () => {
       try {
         setIsLoading(true);
-
-        const dreams: Dream[] = await fetchMyDreams();
+        const dreams: Dream[] = await fetchMyDreams(sortBy);
         setMyDreams(dreams);
       } catch (e) {
         console.error(e);
@@ -35,13 +34,30 @@ const MyDreamPage = () => {
     };
 
     loadMyDreams();
-  }, []);
+  }, [sortBy]);
 
   return (
     <div>
       <Header />
       <SakuraScatterEffect />
-      <MyDreamInput setMyDreams={setMyDreams} />
+
+      <div className="p-4">
+        <MyDreamInput setMyDreams={setMyDreams} />
+
+        {/* ソート選択 */}
+        <div className="mt-3 flex items-center gap-2">
+          <span className="text-gray-600 text-sm">並び替え:</span>
+          <select
+            value={sortBy}
+            onChange={(e) => setSortBy(e.target.value as "updated_at" | "likes")}
+            className="border rounded px-3 py-1 bg-white text-gray-800 text-sm shadow-sm"
+          >
+            <option value="updated_at">更新日順</option>
+            <option value="likes">いいね順</option>
+          </select>
+        </div>
+      </div>
+
       <MyDreamCards myDreams={myDreams} setMyDreams={setMyDreams} />
     </div>
   );

--- a/frontend/src/pages/dreams/mine/MyDreamPage.tsx
+++ b/frontend/src/pages/dreams/mine/MyDreamPage.tsx
@@ -44,13 +44,14 @@ const MyDreamPage = () => {
       <div className="p-4">
         <MyDreamInput setMyDreams={setMyDreams} />
 
-        {/* ソート選択 */}
-        <div className="mt-3 flex items-center gap-2">
-          <span className="text-gray-600 text-sm">並び替え:</span>
+        <div className="mt-3 ml-5 flex items-center gap-2">
+          <span className="text-gray-600">並び替え:</span>
           <select
             value={sortBy}
-            onChange={(e) => setSortBy(e.target.value as "updated_at" | "likes")}
-            className="border rounded px-3 py-1 bg-white text-gray-800 text-sm shadow-sm"
+            onChange={(e) => {
+              setSortBy(e.target.value as "updated_at" | "likes");
+            }}
+            className="border rounded px-3 py-1 bg-white text-gray-800 shadow-sm"
           >
             <option value="updated_at">更新日順</option>
             <option value="likes">いいね順</option>

--- a/openapi.yml
+++ b/openapi.yml
@@ -80,6 +80,17 @@ paths:
       tags: 
         - dreams
       summary: 自分の夢を取得する
+      parameters:
+        - name: sort_by
+          in: query
+          description: ソート順を指定するクエリ
+          required: true
+          schema:
+            type: string
+            enum: 
+              - updated_at
+              - likes
+            default: updated_at
       operationId: getMyDreams
       security:
         - BearerAuth: []


### PR DESCRIPTION
## Issue
- Close #20 

## 概要
ソートを指定できるようにする

## やったこと
バックエンドにて、ソート条件を送信するクエリに対応
フロントエンドにて、ソート条件を指定するボタン設置
![image](https://github.com/user-attachments/assets/1c323f55-6b3b-48e1-bd51-835a58757cb4)

## 動作確認方法
pullして動作確認