### PR TITLE
#59 server log

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,12 +1,15 @@
 # lib
 import os
 from datetime import timedelta
+
+from config.logging_setup import setup_logger
 from dotenv import load_dotenv
+
 # flask lib
 from flask import Flask, request
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager
-from logging_setup import setup_logger
+
 # blueprint
 from routes.auth import auth_bp
 from routes.dream.mine import my_dream_bp
@@ -17,7 +20,7 @@ load_dotenv()
 
 app = Flask(__name__)
 # ログの出力設定
-setup_logger(app,is_production=True)
+setup_logger(app)
 # CORSのセットアップ
 CORS(
     app,

--- a/backend/app.py
+++ b/backend/app.py
@@ -16,7 +16,8 @@ from routes.user import user_bp
 load_dotenv()
 
 app = Flask(__name__)
-setup_logger(app)
+# 本番用の出力はTrue
+setup_logger(app,True)
 # CORSのセットアップ
 CORS(
     app,

--- a/backend/app.py
+++ b/backend/app.py
@@ -17,7 +17,7 @@ load_dotenv()
 
 app = Flask(__name__)
 # ログの出力設定
-setup_logger(app,is_production=False)
+setup_logger(app,is_production=True)
 # CORSのセットアップ
 CORS(
     app,

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,10 +1,13 @@
+# lib
 import os
 from datetime import timedelta
-
 from dotenv import load_dotenv
+# flask lib
 from flask import Flask, request
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager
+from logging_setup import setup_logger
+# blueprint
 from routes.auth import auth_bp
 from routes.dream.mine import my_dream_bp
 from routes.dream.public import public_dream_bp
@@ -13,7 +16,7 @@ from routes.user import user_bp
 load_dotenv()
 
 app = Flask(__name__)
-
+setup_logger(app)
 # CORSのセットアップ
 CORS(
     app,
@@ -52,4 +55,4 @@ def test():  # 生存確認API
 
 
 if __name__ == "__main__":
-    app.run(port=5000, debug=True)
+    app.run(port=5001, debug=True)

--- a/backend/app.py
+++ b/backend/app.py
@@ -16,8 +16,8 @@ from routes.user import user_bp
 load_dotenv()
 
 app = Flask(__name__)
-# 本番用の出力はTrue
-setup_logger(app,True)
+# ログの出力設定
+setup_logger(app,is_production=False)
 # CORSのセットアップ
 CORS(
     app,
@@ -52,8 +52,9 @@ def test():  # 生存確認API
     if request.method == "HEAD":
         return "", 200
     elif request.method == "GET":
+        app.logger.info("GET request")
         return "Hello", 200
 
 
 if __name__ == "__main__":
-    app.run(port=5001, debug=True)
+    app.run(port=5000, debug=True)

--- a/backend/logging_setup.py
+++ b/backend/logging_setup.py
@@ -1,0 +1,18 @@
+import logging
+from rich.logging import RichHandler
+
+def setup_logger(app):
+    # デフォルトハンドラを削除
+    if app.logger.hasHandlers():
+        app.logger.removeHandler(app.logger.handlers[0])
+
+    # RichHandler設定
+    handler = RichHandler(markup=True, rich_tracebacks=True)
+    formatter = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+        datefmt="[%X]"
+    )
+    handler.setFormatter(formatter)
+
+    app.logger.setLevel(logging.DEBUG)
+    app.logger.addHandler(handler)

--- a/backend/logging_setup.py
+++ b/backend/logging_setup.py
@@ -1,18 +1,15 @@
 import logging
 from rich.logging import RichHandler
 
-def setup_logger(app):
+def setup_logger(app, is_production=False):
     # デフォルトハンドラを削除
-    if app.logger.hasHandlers():
-        app.logger.removeHandler(app.logger.handlers[0])
+    for h in app.logger.handlers[:]:
+        app.logger.removeHandler(h)
 
-    # RichHandler設定
+    # ロガーをセット
     handler = RichHandler(markup=True, rich_tracebacks=True)
-    formatter = logging.Formatter(
-        "%(asctime)s [%(levelname)s] %(name)s - %(message)s",
-        datefmt="[%X]"
-    )
-    handler.setFormatter(formatter)
-
-    app.logger.setLevel(logging.DEBUG)
+    app.logger.setLevel(logging.INFO)
     app.logger.addHandler(handler)
+    # 本番はwerkzeugのログ（標準）を無効
+    if is_production:
+        logging.getLogger('werkzeug').disabled = True

--- a/backend/logging_setup.py
+++ b/backend/logging_setup.py
@@ -1,15 +1,29 @@
 import logging
+from flask import has_request_context, request
 from rich.logging import RichHandler
 
+# ログの出力にメソッドとパスを追記する
+class RequestPathFilter(logging.Filter):
+    def filter(self, record):
+        if has_request_context():
+            record.request_path = f"{request.method} {request.path}"
+        else:
+            record.request_path = "-"
+        return True
+# ロガーのセットアップ
 def setup_logger(app, is_production=False):
-    # デフォルトハンドラを削除
-    for h in app.logger.handlers[:]:
+    for h in app.logger.handlers[:]: # 既存ロガーの削除
         app.logger.removeHandler(h)
+    # 本番用ロガー
+    handler = RichHandler(markup=True, rich_tracebacks=True, show_path= not is_production)
 
-    # ロガーをセット
-    handler = RichHandler(markup=True, rich_tracebacks=True)
+    formatter = logging.Formatter("%(request_path)s - %(message)s")
+    handler.setFormatter(formatter)
+
+    handler.addFilter(RequestPathFilter())
+    # INFOレベル以上のみ
     app.logger.setLevel(logging.INFO)
     app.logger.addHandler(handler)
-    # 本番はwerkzeugのログ（標準）を無効
-    if is_production:
+    # 開発用
+    if is_production: # 標準ログを有効に
         logging.getLogger('werkzeug').disabled = True

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ Flask-JWT-Extended~=4.7.1
 supabase==2.13.0
 gunicorn==23.0.0
 pydantic==2.10.6
+rich==13.9.4

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -43,7 +43,7 @@ def login_with_oauth():
     credentials = request.get_json()
     user_id = credentials["userId"]
     if user_id is None:
-        current_app.logger.error("Credentials are incorrect")
+        current_app.logger.error("User ID is required")
         return "User ID is required", 401
 
     response = make_response("", 200)

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, make_response, request
+from flask import Blueprint, jsonify, make_response, request, current_app
 from flask_jwt_extended import create_access_token
 from models.db import get_supabase_client
 from supabase import Client
@@ -22,6 +22,7 @@ def login():
     user = response.user
     # userを取得できなかった場合
     if user is None:
+        current_app.logger.error("Credentials are incorrect")
         return "Credentials are incorrect", 401
 
     # ユーザーID から JWT を生成
@@ -42,6 +43,7 @@ def login_with_oauth():
     credentials = request.get_json()
     user_id = credentials["userId"]
     if user_id is None:
+        current_app.logger.error("Credentials are incorrect")
         return "User ID is required", 401
 
     response = make_response("", 200)

--- a/backend/routes/dream/mine.py
+++ b/backend/routes/dream/mine.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, current_app
 from flask_jwt_extended import get_jwt_identity, jwt_required
 from models.dream import Dream
 from pydantic import ValidationError
@@ -7,7 +7,6 @@ from schemas.dream.mine import CreateMyDreamRequest, GetMyDreamsParams, MyDreamR
 my_dream_bp = Blueprint("my_dream", __name__)
 
 
-# 自分が作成した夢を取得
 @my_dream_bp.route("/dreams/mine", methods=["GET"])
 @jwt_required()
 def get_my_dreams():
@@ -15,38 +14,44 @@ def get_my_dreams():
 
     try:
         params = GetMyDreamsParams(**request.args)
-    except ValidationError:
+    except ValidationError as e:
+        current_app.logger.error("Invalid query parameters", exc_info=e)
         return "Invalid query parameter", 400
 
     dreams = Dream.get_all_by_user(user_id, params.sort_by)
 
     try:
         dreams = [MyDreamResponse(**dream.__dict__) for dream in dreams]
-    except ValidationError:
+    except ValidationError as e:
+        current_app.logger.error("Response validation failed", exc_info=e)
         return "Response Validation Error", 500
 
     return jsonify([dream.model_dump() for dream in dreams]), 200
 
 
-# 夢を新規作成
 @my_dream_bp.route("/dreams/mine", methods=["POST"])
 @jwt_required()
 def create_my_dream():
+
     body = request.get_json()
+
     try:
         body = CreateMyDreamRequest(**body)
-    except ValidationError:
+    except ValidationError as e:
+        current_app.logger.error("Invalid request body", exc_info=e)
         return "Invalid request body", 400
 
-    # JWTのヘッダからユーザーIDを取得
     user_id = get_jwt_identity()
-
-    # 夢とハッシュタグのテーブルにデータを追加
-    created_dream = Dream.create_with_hashtags(user_id, body)
+    try:
+        created_dream = Dream.create_with_hashtags(user_id, body)
+    except Exception as e:
+        current_app.logger.exception("Failed to create dream")
+        return "Internal server error", 500
 
     try:
         created_dream = MyDreamResponse(**created_dream.__dict__)
-    except ValidationError:
+    except ValidationError as e:
+        current_app.logger.error("Response validation error", exc_info=e)
         return "Response Validation Error", 500
 
     return jsonify(created_dream.model_dump()), 201
@@ -55,23 +60,35 @@ def create_my_dream():
 @my_dream_bp.route("/dreams/mine/<int:dream_id>", methods=["PATCH"])
 @jwt_required()
 def toggle_visibility(dream_id: int):
-    updated_dream = Dream.toggle_visibility(dream_id)
+    try:
+        updated_dream = Dream.toggle_visibility(dream_id)
+    except Exception as e:
+        current_app.logger.error.exception(f"Failed to toggle visibility for dream_id={dream_id}")
+        return "Internal Server Error", 500
+
     if updated_dream is None:
+        current_app.logger.warning(f"Dream with id {dream_id} not found for visibility toggle")
         return "", 404
 
     try:
         updated_dream = MyDreamResponse(**updated_dream.__dict__)
-    except ValidationError:
+    except ValidationError as e:
+        current_app.logger.error("Response validation error", exc_info=e)
         return "Response Validation Error", 500
 
     return jsonify(updated_dream.model_dump()), 200
 
 
-# 夢を削除
 @my_dream_bp.route("/dreams/mine/<int:dream_id>", methods=["DELETE"])
 @jwt_required()
 def delete_my_dream(dream_id: int):
-    if Dream.delete(dream_id):
-        return "", 204  # 削除成功
-    else:
-        return "", 404  # 夢が存在しない
+    try:
+        if Dream.delete(dream_id):
+            current_app.logger.info(f"Deleted dream {dream_id}")
+            return "", 204
+        else:
+            current_app.logger.warning(f"Attempted to delete non-existing dream {dream_id}")
+            return "", 404
+    except Exception as e:
+        current_app.logger.exception("Failed to delete dream")
+        return "Internal Server Error", 500

--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -12,17 +12,17 @@ def create_user():
     try:
         body = CreateUserBody(**body)
     except ValidationError:
-        current_app.logger.error("Validation Error")
+        current_app.logger.error("Validation Error of request body")
         return "Invalid request body", 400
 
     user = User.get_user_by_email(body.email)
     if user is not None:
-        current_app.logger.error("Validation Error")
+        current_app.logger.error("Email is already taken")
         return "Email is already taken", 409
 
     new_user = User.create_user(body.email, body.password)
     if new_user is None:
-        current_app.logger.error("Validation Error")
+        current_app.logger.error("Failed to create user")
         return "Failed to create user", 500
 
     try:

--- a/backend/routes/user.py
+++ b/backend/routes/user.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, current_app
 from models.user import User
 from pydantic import ValidationError
 from schemas.user import CreateUserBody, UserResponse
@@ -12,19 +12,23 @@ def create_user():
     try:
         body = CreateUserBody(**body)
     except ValidationError:
+        current_app.logger.error("Validation Error")
         return "Invalid request body", 400
 
     user = User.get_user_by_email(body.email)
     if user is not None:
+        current_app.logger.error("Validation Error")
         return "Email is already taken", 409
 
     new_user = User.create_user(body.email, body.password)
     if new_user is None:
+        current_app.logger.error("Validation Error")
         return "Failed to create user", 500
 
     try:
         new_user = UserResponse(**new_user.__dict__)
     except ValidationError:
+        current_app.logger.error("Response Validation Error")
         return "Response Validation Error", 500
 
     return jsonify(new_user.model_dump()), 201

--- a/backend/schemas/dream/mine.py
+++ b/backend/schemas/dream/mine.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Optional
+from flask import current_app
 
 from pydantic import (
     BaseModel,
@@ -48,6 +49,8 @@ class CreateMyDreamRequest(BaseModel):
     @field_validator("content")
     def validate_content(cls, content: str) -> str:
         if len(content) == 0:
+            # 空白エラー
+            current_app.logger.error("Content is required")
             raise ValidationError("Content is required")
 
         return content


### PR DESCRIPTION
## Issue
- Close #59 
## 概要
Flask標準出力のログと本番用のオリジナルログの出力を分ける。
## やったこと
- loggerを追加、開発環境のときは標準、オリジナルログが両方出力。本番はオリジナルログのみ出力
- オリジナルログはエラーハンドリングが施されている部分のみ実装
- フォーマットはこんな感じ
```
[03/30/25 15:13:18] INFO     GET /test - GET request 
```

## 動作確認方法
実際にブランチを受け継いで動作確認してみて。場合によってはPytestの導入も必要かも