### PR TITLE
74-sort-card

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,8 +14,8 @@ COPY . .
 # ポート5000を公開
 EXPOSE 5000
 
-# 環境変数の設定（本番環境）
-ENV FLASK_ENV=production
+# 環境変数の設定  dev -> 1, pd -> 0
+ENV FLASK_DEBUG=1
 
 # GunicornでFlaskアプリを起動
 CMD ["gunicorn", "-b", "0.0.0.0:5000", "app:app"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -183,6 +183,20 @@ $$;
 CREATE TRIGGER sync_auth_users
   AFTER INSERT OR UPDATE OR DELETE ON auth.users
   FOR EACH ROW EXECUTE PROCEDURE public.sync_auth_users_to_public_users();
+
+--- Function to sync update_at to datetime now
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER set_updated_at
+BEFORE UPDATE ON dreams
+FOR EACH ROW
+EXECUTE FUNCTION update_updated_at_column();
+
 ```
 
 `seeds` 以下のスクリプトを実行してサンプルデータを追加する．

--- a/backend/app.py
+++ b/backend/app.py
@@ -62,4 +62,4 @@ def test():  # 生存確認API
 
 
 if __name__ == "__main__":
-    app.run(port=5001, debug=True)
+    app.run(port=5000, debug=True)

--- a/backend/app.py
+++ b/backend/app.py
@@ -19,6 +19,8 @@ from routes.user import user_bp
 load_dotenv()
 
 app = Flask(__name__)
+# 環境設定
+app.debug = os.environ.get("FLASK_DEBUG") == "1"
 # ログの出力設定
 setup_logger(app)
 # CORSのセットアップ
@@ -60,4 +62,4 @@ def test():  # 生存確認API
 
 
 if __name__ == "__main__":
-    app.run(port=5000, debug=True)
+    app.run(port=5001, debug=True)

--- a/backend/config/logging_setup.py
+++ b/backend/config/logging_setup.py
@@ -17,6 +17,8 @@ class RequestPathFilter(logging.Filter):
 
 # ロガーのセットアップ
 def setup_logger(app: Flask):
+    if app.config["ENV"] == "development":
+        return  # ← ローカルなら何も設定しない
     # 既存ロガーの削除
     for h in app.logger.handlers:
         app.logger.removeHandler(h)

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = test

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ supabase==2.13.0
 gunicorn==23.0.0
 pydantic==2.10.6
 rich==13.9.4
+pytest==8.3.5

--- a/backend/test/integration/sort_time_integration_test.py
+++ b/backend/test/integration/sort_time_integration_test.py
@@ -6,41 +6,59 @@ from supabase import Client
 
 supabase: Client = get_supabase_client()
 
+# testuser1 の user_id（Supabaseで確認して値を設定）
+TEST_USER_ID = "d7fc2a83-3046-48f1-94e7-bfd9a6b9ba3e"  # UUIDでもOK、authに登録されたID
+
+
 @pytest.mark.skipif(supabase is None, reason="Supabase client not initialized")
 def test_updated_at_and_sorting_behavior():
-    dream_id = 97  # testuser1の「賞を取る！！！」を操作
+    # --- 0. テスト用レコードを作成 ---
+    unique_content = f"pytest content {time.time()}"
+    insert_res = supabase.table("dreams").insert({
+        "user_id": TEST_USER_ID,
+        "content": unique_content,
+        "is_public": True
+    }).execute()
 
-    # --- 1. 更新前の updated_at を取得 ---
-    before_res = supabase.table("dreams").select("updated_at").eq("id", dream_id).execute()
-    assert before_res.data, "❌ レコードが存在しません"
-    before_time = datetime.fromisoformat(before_res.data[0]["updated_at"])
+    assert insert_res.data, "❌ レコードの作成に失敗"
+    dream_id = insert_res.data[0]["id"]
 
-    # --- 2. content をユニークな文字列に更新 ---
-    supabase.table("dreams").update({
-        "content": f"pytest test {time.time()}"
-    }).eq("id", dream_id).execute()
+    try:
+        # --- 1. 更新前の updated_at を取得 ---
+        before_res = supabase.table("dreams").select("updated_at").eq("id", dream_id).execute()
+        assert before_res.data, "❌ レコードが存在しません"
+        before_time = datetime.fromisoformat(before_res.data[0]["updated_at"])
 
-    # --- 3. 反映を待つ ---
-    time.sleep(1)
+        # --- 2. content をユニークな文字列に更新 ---
+        supabase.table("dreams").update({
+            "content": f"pytest updated {time.time()}"
+        }).eq("id", dream_id).execute()
 
-    # --- 4. updated_at が更新されているか確認 ---
-    after_res = supabase.table("dreams").select("updated_at").eq("id", dream_id).execute()
-    after_time = datetime.fromisoformat(after_res.data[0]["updated_at"])
+        # --- 3. 反映を待つ ---
+        time.sleep(1)
 
-    assert after_time > before_time, f"❌ updated_at が更新されていません: {before_time} vs {after_time}"
+        # --- 4. updated_at が更新されているか確認 ---
+        after_res = supabase.table("dreams").select("updated_at").eq("id", dream_id).execute()
+        after_time = datetime.fromisoformat(after_res.data[0]["updated_at"])
 
-    # --- 5. updated_at による降順ソートの確認 ---
-    sorted_res = supabase.table("dreams").select("id, updated_at").order("updated_at", desc=True).execute()
-    sorted_ids = [record["id"] for record in sorted_res.data]
+        assert after_time > before_time, f"❌ updated_at が更新されていません: {before_time} vs {after_time}"
 
-    assert dream_id == sorted_ids[0], f"❌ 更新時間順ソート順が正しくない（更新したIDが先頭にいない）: {sorted_ids}"
+        # --- 5. updated_at による降順ソートの確認 ---
+        sorted_res = supabase.table("dreams").select("id, updated_at").order("updated_at", desc=True).execute()
+        sorted_ids = [record["id"] for record in sorted_res.data]
 
-    print(f"✅ updated_at ソート順 OK, 最新ID = {sorted_ids[0]}")
+        assert dream_id == sorted_ids[0], f"❌ ソート順が正しくない: {sorted_ids}"
+        print(f"✅ updated_at ソート順 OK, 最新ID = {sorted_ids[0]}")
 
-    # --- 6. likes によるソートの検証（降順） ---
-    like_sorted_res = supabase.table("dreams").select("id, likes").order("likes", desc=True).execute()
-    like_counts = [record["likes"] for record in like_sorted_res.data]
+        # --- 6. likes によるソートの検証（降順） ---
+        like_sorted_res = supabase.table("dreams").select("id, likes").order("likes", desc=True).execute()
+        like_counts = [record["likes"] for record in like_sorted_res.data]
 
-    assert like_counts == sorted(like_counts, reverse=True), f"❌ likes の降順ソートが正しくありません: {like_counts}"
+        assert like_counts == sorted(like_counts,
+                                     reverse=True), f"❌ likes の降順ソートが正しくありません: {like_counts}"
+        print(f"✅ likes ソート順 OK: {like_counts}")
 
-    print(f"✅ likes ソート順 OK: {like_counts}")
+    finally:
+        # --- 後始末（テストデータ削除） ---
+        supabase.table("dreams").delete().eq("id", dream_id).execute()
+        print(f"✅ テストデータの削除完了")

--- a/backend/test/integration/sort_time_integration_test.py
+++ b/backend/test/integration/sort_time_integration_test.py
@@ -13,7 +13,7 @@ TEST_USER_ID = "d7fc2a83-3046-48f1-94e7-bfd9a6b9ba3e"  # UUIDでもOK、authに�
 @pytest.mark.skipif(supabase is None, reason="Supabase client not initialized")
 def test_updated_at_and_sorting_behavior():
     # --- 0. テスト用レコードを作成 ---
-    unique_content = f"pytest content {time.time()}"
+    unique_content = f"pytest content {datetime.utcnow().isoformat()}"
     insert_res = supabase.table("dreams").insert({
         "user_id": TEST_USER_ID,
         "content": unique_content,
@@ -28,14 +28,14 @@ def test_updated_at_and_sorting_behavior():
         before_res = supabase.table("dreams").select("updated_at").eq("id", dream_id).execute()
         assert before_res.data, "❌ レコードが存在しません"
         before_time = datetime.fromisoformat(before_res.data[0]["updated_at"])
-
-        # --- 2. content をユニークな文字列に更新 ---
-        supabase.table("dreams").update({
-            "content": f"pytest updated {time.time()}"
-        }).eq("id", dream_id).execute()
-
-        # --- 3. 反映を待つ ---
+        # --- 2. スリープ ---
         time.sleep(1)
+        # --- 3. content をユニークな文字列に更新 ---
+        new_content = f"pytest content {datetime.utcnow().isoformat()}"
+        update_res = supabase.table("dreams").update({
+            "content": new_content
+        }).eq("id",dream_id).execute()
+        assert update_res.data, "❌ レコードの変更に失敗"
 
         # --- 4. updated_at が更新されているか確認 ---
         after_res = supabase.table("dreams").select("updated_at").eq("id", dream_id).execute()

--- a/backend/test/integration/sort_time_integration_test.py
+++ b/backend/test/integration/sort_time_integration_test.py
@@ -1,64 +1,87 @@
 import time
-from datetime import datetime
-from models.db import get_supabase_client
+from datetime import UTC, datetime
+
 import pytest
+from models.db import get_supabase_client
 from supabase import Client
 
 supabase: Client = get_supabase_client()
 
 # testuser1 の user_id（Supabaseで確認して値を設定）
-TEST_USER_ID = "d7fc2a83-3046-48f1-94e7-bfd9a6b9ba3e"  # UUIDでもOK、authに登録されたID
+TEST_USER_ID = "d7fc2a83-3046-48f1-94e7-bfd9a6b9ba3e"
 
 
 @pytest.mark.skipif(supabase is None, reason="Supabase client not initialized")
 def test_updated_at_and_sorting_behavior():
     # --- 0. テスト用レコードを作成 ---
-    unique_content = f"pytest content {datetime.utcnow().isoformat()}"
-    insert_res = supabase.table("dreams").insert({
-        "user_id": TEST_USER_ID,
-        "content": unique_content,
-        "is_public": True
-    }).execute()
+    unique_content = f"pytest content {datetime.now(UTC).isoformat()}"
+    insert_res = (
+        supabase.table("dreams")
+        .insert({"user_id": TEST_USER_ID, "content": unique_content, "is_public": True})
+        .execute()
+    )
 
     assert insert_res.data, "❌ レコードの作成に失敗"
     dream_id = insert_res.data[0]["id"]
 
     try:
         # --- 1. 更新前の updated_at を取得 ---
-        before_res = supabase.table("dreams").select("updated_at").eq("id", dream_id).execute()
+        before_res = (
+            supabase.table("dreams").select("updated_at").eq("id", dream_id).execute()
+        )
         assert before_res.data, "❌ レコードが存在しません"
         before_time = datetime.fromisoformat(before_res.data[0]["updated_at"])
+
         # --- 2. スリープ ---
         time.sleep(1)
+
         # --- 3. content をユニークな文字列に更新 ---
-        new_content = f"pytest content {datetime.utcnow().isoformat()}"
-        update_res = supabase.table("dreams").update({
-            "content": new_content
-        }).eq("id",dream_id).execute()
+        new_content = f"pytest content {datetime.now(UTC).isoformat()}"
+        update_res = (
+            supabase.table("dreams")
+            .update({"content": new_content})
+            .eq("id", dream_id)
+            .execute()
+        )
         assert update_res.data, "❌ レコードの変更に失敗"
 
         # --- 4. updated_at が更新されているか確認 ---
-        after_res = supabase.table("dreams").select("updated_at").eq("id", dream_id).execute()
+        after_res = (
+            supabase.table("dreams").select("updated_at").eq("id", dream_id).execute()
+        )
         after_time = datetime.fromisoformat(after_res.data[0]["updated_at"])
 
-        assert after_time > before_time, f"❌ updated_at が更新されていません: {before_time} vs {after_time}"
+        assert after_time > before_time, (
+            f"❌ updated_at が更新されていません: {before_time} vs {after_time}"
+        )
 
         # --- 5. updated_at による降順ソートの確認 ---
-        sorted_res = supabase.table("dreams").select("id, updated_at").order("updated_at", desc=True).execute()
+        sorted_res = (
+            supabase.table("dreams")
+            .select("id, updated_at")
+            .order("updated_at", desc=True)
+            .execute()
+        )
         sorted_ids = [record["id"] for record in sorted_res.data]
 
         assert dream_id == sorted_ids[0], f"❌ ソート順が正しくない: {sorted_ids}"
         print(f"✅ updated_at ソート順 OK, 最新ID = {sorted_ids[0]}")
 
         # --- 6. likes によるソートの検証（降順） ---
-        like_sorted_res = supabase.table("dreams").select("id, likes").order("likes", desc=True).execute()
+        like_sorted_res = (
+            supabase.table("dreams")
+            .select("id, likes")
+            .order("likes", desc=True)
+            .execute()
+        )
         like_counts = [record["likes"] for record in like_sorted_res.data]
 
-        assert like_counts == sorted(like_counts,
-                                     reverse=True), f"❌ likes の降順ソートが正しくありません: {like_counts}"
+        assert like_counts == sorted(like_counts, reverse=True), (
+            f"❌ likes の降順ソートが正しくありません: {like_counts}"
+        )
         print(f"✅ likes ソート順 OK: {like_counts}")
 
     finally:
         # --- 後始末（テストデータ削除） ---
         supabase.table("dreams").delete().eq("id", dream_id).execute()
-        print(f"✅ テストデータの削除完了")
+        print("✅ テストデータの削除完了")

--- a/backend/test/integration/sort_time_integration_test.py
+++ b/backend/test/integration/sort_time_integration_test.py
@@ -1,0 +1,46 @@
+import time
+from datetime import datetime
+from models.db import get_supabase_client
+import pytest
+from supabase import Client
+
+supabase: Client = get_supabase_client()
+
+@pytest.mark.skipif(supabase is None, reason="Supabase client not initialized")
+def test_updated_at_and_sorting_behavior():
+    dream_id = 97  # testuser1の「賞を取る！！！」を操作
+
+    # --- 1. 更新前の updated_at を取得 ---
+    before_res = supabase.table("dreams").select("updated_at").eq("id", dream_id).execute()
+    assert before_res.data, "❌ レコードが存在しません"
+    before_time = datetime.fromisoformat(before_res.data[0]["updated_at"])
+
+    # --- 2. content をユニークな文字列に更新 ---
+    supabase.table("dreams").update({
+        "content": f"pytest test {time.time()}"
+    }).eq("id", dream_id).execute()
+
+    # --- 3. 反映を待つ ---
+    time.sleep(1)
+
+    # --- 4. updated_at が更新されているか確認 ---
+    after_res = supabase.table("dreams").select("updated_at").eq("id", dream_id).execute()
+    after_time = datetime.fromisoformat(after_res.data[0]["updated_at"])
+
+    assert after_time > before_time, f"❌ updated_at が更新されていません: {before_time} vs {after_time}"
+
+    # --- 5. updated_at による降順ソートの確認 ---
+    sorted_res = supabase.table("dreams").select("id, updated_at").order("updated_at", desc=True).execute()
+    sorted_ids = [record["id"] for record in sorted_res.data]
+
+    assert dream_id == sorted_ids[0], f"❌ 更新時間順ソート順が正しくない（更新したIDが先頭にいない）: {sorted_ids}"
+
+    print(f"✅ updated_at ソート順 OK, 最新ID = {sorted_ids[0]}")
+
+    # --- 6. likes によるソートの検証（降順） ---
+    like_sorted_res = supabase.table("dreams").select("id, likes").order("likes", desc=True).execute()
+    like_counts = [record["likes"] for record in like_sorted_res.data]
+
+    assert like_counts == sorted(like_counts, reverse=True), f"❌ likes の降順ソートが正しくありません: {like_counts}"
+
+    print(f"✅ likes ソート順 OK: {like_counts}")


### PR DESCRIPTION
## Issue
- Close #74
## 概要
公開・非公開で切り替えた時意味不明な並べ替えを実行する
## やったこと
- そもそもログの表示をdevとproductionでうまく切り替えれてなかったので改善
- supabaseのSQLにて，update_atを自動更新するようにトリガ，関数設定
- それを検証するテストを作成，pytestまたはそれに対応するフォルダの用意
## 動作確認方法
以下コマンドを実行すること
```
PYTHONPATH=. pytest -s
```